### PR TITLE
Can specify headers when registering stream

### DIFF
--- a/lib/servers/standalone.js
+++ b/lib/servers/standalone.js
@@ -30,11 +30,11 @@ class StandaloneServer {
       req.setEncoding("utf8");
       req.on('data', data => { content += data });
 
-      req.on('end', () => {
+      req.once('end', () => {
         try { var body = content ? JSON.parse(content) : {} }
         catch(err) { return this._reply403(res) }
 
-        var sess = this._manager.createSession(body.download_headers);
+        var sess = this._manager.createSession(body.download_headers, body.upload_headers);
         this.logger.info('session '+sess.id+' created');
 
         res.statusCode = 201;
@@ -52,6 +52,13 @@ class StandaloneServer {
       catch(err) { return this._reply403(res); }
 
       res.setHeader('connection', 'close');
+
+      // map upload_headers object key/values to actual response header/values
+      for (var header in sess.upload_headers) {
+        this.logger.info('setting provided upload header: '+header);
+        res.setHeader(header, sess.upload_headers[header]);
+      }
+
       sess.on('timeout', sess => this._reply504(res));
       sess.on('streaming', sess => res.statusCode = 200);
       sess.on('error', err => this._onSessionError('src', sess, err, req, res));
@@ -70,12 +77,11 @@ class StandaloneServer {
 
       // map download_headers object key/values to actual response header/values
       for (var header in sess.download_headers) {
-        this.logger.info('setting provided header: '+header);
+        this.logger.info('setting provided download header: '+header);
         res.setHeader(header, sess.download_headers[header]);
       }
 
       sess.on('streaming', sess => res.statusCode = 200);
-
       sess.on('timeout', sess => this._reply504(res));
       sess.on('error', err => this._onSessionError('dst', sess, err, req, res));
       sess.on('finished', sess => res.end());

--- a/lib/servers/standalone.js
+++ b/lib/servers/standalone.js
@@ -26,19 +26,15 @@ class StandaloneServer {
 
     // POST /session
     if(this._isCreate(req.method, req.url)) {
+      var content = "";
       req.setEncoding("utf8");
-
-      let content = "";
-      req.on('data', data => {
-        content += data;
-      });
+      req.on('data', data => { content += data });
 
       req.on('end', () => {
-        let body;
-        try { body = content ? JSON.parse(content) : {} }
+        try { var body = content ? JSON.parse(content) : {} }
         catch(err) { return this._reply403(res) }
 
-        var sess = this._manager.createSession(body.content_type, body.filename);
+        var sess = this._manager.createSession(body.download_headers);
         this.logger.info('session '+sess.id+' created');
 
         res.statusCode = 201;
@@ -71,8 +67,12 @@ class StandaloneServer {
       catch(err) { return this._reply403(res); }
 
       res.setHeader('connection', 'close');
-      if (sess.content_type) res.setHeader('Content-Type', sess.content_type);
-      if (sess.filename) res.setHeader('Content-Disposition', `attachment; filename="${sess.filename}"`)
+
+      // map download_headers object key/values to actual response header/values
+      for (var header in sess.download_headers) {
+        this.logger.info('setting provided header: '+header);
+        res.setHeader(header, sess.download_headers[header]);
+      }
 
       sess.on('streaming', sess => res.statusCode = 200);
 

--- a/lib/servers/standalone.js
+++ b/lib/servers/standalone.js
@@ -26,12 +26,25 @@ class StandaloneServer {
 
     // POST /session
     if(this._isCreate(req.method, req.url)) {
-      var sess = this._manager.createSession();
-      this.logger.info('session '+sess.id+' created');
+      req.setEncoding("utf8");
 
-      res.statusCode = 201;
-      res.setHeader('content-type', 'application/json');
-      return res.end('{"stream":"'+sess.id+'"}');
+      let content = "";
+      req.on('data', data => {
+        content += data;
+      });
+
+      req.on('end', () => {
+        let body;
+        try { body = content ? JSON.parse(content) : {} }
+        catch(err) { return this._reply403(res) }
+
+        var sess = this._manager.createSession(body.content_type, body.filename);
+        this.logger.info('session '+sess.id+' created');
+
+        res.statusCode = 201;
+        res.setHeader('content-type', 'application/json');
+        return res.end('{"stream":"'+sess.id+'"}');
+      });
     }
 
     // PUT /session/{id}
@@ -58,8 +71,12 @@ class StandaloneServer {
       catch(err) { return this._reply403(res); }
 
       res.setHeader('connection', 'close');
-      sess.on('timeout', sess => this._reply504(res));
+      if (sess.content_type) res.setHeader('Content-Type', sess.content_type);
+      if (sess.filename) res.setHeader('Content-Disposition', `attachment; filename="${sess.filename}"`)
+
       sess.on('streaming', sess => res.statusCode = 200);
+
+      sess.on('timeout', sess => this._reply504(res));
       sess.on('error', err => this._onSessionError('dst', sess, err, req, res));
       sess.on('finished', sess => res.end());
     }

--- a/lib/servers/standalone.js
+++ b/lib/servers/standalone.js
@@ -32,7 +32,7 @@ class StandaloneServer {
 
       req.once('end', () => {
         try { var body = content ? JSON.parse(content) : {} }
-        catch(err) { return this._reply403(res) }
+        catch(err) { return this._replyBadRequest(res) }
 
         var sess = this._manager.createSession(body.download_headers, body.upload_headers);
         this.logger.info('session '+sess.id+' created');
@@ -46,10 +46,10 @@ class StandaloneServer {
     // PUT /session/{id}
     else if(this._isSrc(req.method, req.url)) {
       var sess = this._manager.getSession(this._getStreamId(req.url));
-      if(!sess) return this._reply404(res);
+      if(!sess) return this._replyNotFound(res);
 
       try { sess.registerSource(req) }
-      catch(err) { return this._reply403(res); }
+      catch(err) { return this._replyForbidden(res); }
 
       res.setHeader('connection', 'close');
 
@@ -59,7 +59,7 @@ class StandaloneServer {
         res.setHeader(header, sess.upload_headers[header]);
       }
 
-      sess.on('timeout', sess => this._reply504(res));
+      sess.on('timeout', sess => this._replyGatewayTimeout(res));
       sess.on('streaming', sess => res.statusCode = 200);
       sess.on('error', err => this._onSessionError('src', sess, err, req, res));
       sess.on('finished', sess => res.end());
@@ -68,10 +68,10 @@ class StandaloneServer {
     // GET /session/{id}
     else if(this._isDst(req.method, req.url)) {
       var sess = this._manager.getSession(this._getStreamId(req.url));
-      if(!sess) return this._reply404(res);
+      if(!sess) return this._replyNotFound(res);
 
       try { sess.registerDestination(res) }
-      catch(err) { return this._reply403(res); }
+      catch(err) { return this._replyForbidden(res); }
 
       res.setHeader('connection', 'close');
 
@@ -82,13 +82,13 @@ class StandaloneServer {
       }
 
       sess.on('streaming', sess => res.statusCode = 200);
-      sess.on('timeout', sess => this._reply504(res));
+      sess.on('timeout', sess => this._replyGatewayTimeout(res));
       sess.on('error', err => this._onSessionError('dst', sess, err, req, res));
       sess.on('finished', sess => res.end());
     }
 
     // 404
-    else return this._reply404(res);
+    else return this._replyNotFound(res);
   }
 
   _isCreate(method, url) { return method === 'POST' && url.search(STREAM_GENERATOR_URL_REGEX) !== -1; }
@@ -96,15 +96,19 @@ class StandaloneServer {
   _isDst(method, url) { return method === 'GET' && url.search(STREAM_URL_REGEX) !== -1; }
   _getStreamId(url) { return url.match(STREAM_URL_REGEX)[1]; }
 
-  _reply404(res, msg) {
+  _replyNotFound(res, msg) {
     res.statusCode = 404;
     return res.end(msg);
   }
-  _reply403(res, msg) {
+  _replyForbidden(res, msg) {
     res.statusCode = 403;
     return res.end(msg);
   }
-  _reply504(res, msg) {
+  _replyBadRequest(res, msg) {
+    res.statusCode = 400;
+    return res.end(msg);
+  }
+  _replyGatewayTimeout(res, msg) {
     res.statusCode = 504;
     return res.end(msg);
   }

--- a/lib/servers/standalone.js
+++ b/lib/servers/standalone.js
@@ -5,6 +5,11 @@ const STREAM_GENERATOR_URL_REGEX = /^\/stream\/?$/;
 const STREAM_URL_REGEX = /^\/stream\/([a-zA-Z0-9-_]+)\/?$/;
 const SESSION_TTL = 60000;
 
+// per RFC 7230 Section 3.2.6
+const HEADER_KEY_REGEX = /^[\w!#$%&|~‘’^\*\+\-\.]+$/;
+// per RFC 7230 Section 3.2 and RFC 5234 Appendix B.1
+const HEADER_VAL_REGEX = /^[\u0021-\u007E \t]*$/;
+
 const STREAM_ERRORS = {
   'SRC_ERROR': JSON.stringify({name: 'StreamSourceError', message: 'Stream source raised an error'}),
   'DST_ERROR': JSON.stringify({name: 'StreamDestinationError', message: 'Stream destination raised an error'}),
@@ -31,8 +36,8 @@ class StandaloneServer {
       req.on('data', data => { content += data });
 
       req.once('end', () => {
-        try { var body = content ? JSON.parse(content) : {} }
-        catch(err) { return this._replyBadRequest(res) }
+        try { var body = this._parseCreateContent(content) }
+        catch(err) { return this._replyBadRequest(res, err.message) }
 
         var sess = this._manager.createSession(body.download_headers, body.upload_headers);
         this.logger.info('session '+sess.id+' created');
@@ -95,6 +100,27 @@ class StandaloneServer {
   _isSrc(method, url) { return method === 'PUT' && url.search(STREAM_URL_REGEX) !== -1; }
   _isDst(method, url) { return method === 'GET' && url.search(STREAM_URL_REGEX) !== -1; }
   _getStreamId(url) { return url.match(STREAM_URL_REGEX)[1]; }
+
+  _parseCreateContent(content) {
+    var body = { download_headers:[], upload_headers:[] };
+    if (!content) return body;
+
+    try { body = JSON.parse(content) || body }
+    catch(err) { throw new Error(`Invalid JSON: ${err.message}`) }
+
+    for (var header_set of [body.download_headers, body.upload_headers]) {
+      for (var header in header_set) {
+        if (header.search(HEADER_KEY_REGEX) === -1) {
+          throw new Error(`Not a valid HTTP header name: ${header}`);
+        }
+        if (String(header_set[header]).search(HEADER_VAL_REGEX) === -1) {
+          throw new Error(`Not a valid HTTP header value: "${header_set[header]}"`);
+        }
+      }
+    }
+
+    return body;
+  }
 
   _replyNotFound(res, msg) {
     res.statusCode = 404;

--- a/lib/session-manager.js
+++ b/lib/session-manager.js
@@ -13,8 +13,8 @@ class SessionManager {
     this.SESSION_TTL = opts.session_ttl || SESSION_TTL;
   }
 
-  createSession(content_type, filename) {
-    var session = new Session({id: uuid(), ttl: this.SESSION_TTL, logger: this.logger, content_type: content_type, filename: filename});
+  createSession(download_headers) {
+    var session = new Session({id: uuid(), ttl: this.SESSION_TTL, logger: this.logger, download_headers: download_headers});
     this._sessions[session.id] = session;
     session.once('deleted', session => delete this._sessions[session.id]);
     return session;
@@ -32,8 +32,7 @@ class Session extends EventEmitter {
     this._src = undefined;
     this._dst = undefined;
     this._piped = false;
-    this.content_type = opts.content_type;
-    this.filename = opts.filename;
+    this.download_headers = opts.download_headers;
     this.bytes_transferred = 0;
     this._timeout = setTimeout(this._onTimeout.bind(this), opts.ttl);
   }

--- a/lib/session-manager.js
+++ b/lib/session-manager.js
@@ -13,8 +13,8 @@ class SessionManager {
     this.SESSION_TTL = opts.session_ttl || SESSION_TTL;
   }
 
-  createSession() {
-    var session = new Session({id: uuid(), ttl: this.SESSION_TTL, logger: this.logger});
+  createSession(content_type, filename) {
+    var session = new Session({id: uuid(), ttl: this.SESSION_TTL, logger: this.logger, content_type: content_type, filename: filename});
     this._sessions[session.id] = session;
     session.once('deleted', session => delete this._sessions[session.id]);
     return session;
@@ -32,6 +32,8 @@ class Session extends EventEmitter {
     this._src = undefined;
     this._dst = undefined;
     this._piped = false;
+    this.content_type = opts.content_type;
+    this.filename = opts.filename;
     this.bytes_transferred = 0;
     this._timeout = setTimeout(this._onTimeout.bind(this), opts.ttl);
   }

--- a/lib/session-manager.js
+++ b/lib/session-manager.js
@@ -13,8 +13,8 @@ class SessionManager {
     this.SESSION_TTL = opts.session_ttl || SESSION_TTL;
   }
 
-  createSession(download_headers) {
-    var session = new Session({id: uuid(), ttl: this.SESSION_TTL, logger: this.logger, download_headers: download_headers});
+  createSession(download_headers, upload_headers) {
+    var session = new Session({id: uuid(), ttl: this.SESSION_TTL, logger: this.logger, download_headers: download_headers, upload_headers: upload_headers});
     this._sessions[session.id] = session;
     session.once('deleted', session => delete this._sessions[session.id]);
     return session;
@@ -33,6 +33,7 @@ class Session extends EventEmitter {
     this._dst = undefined;
     this._piped = false;
     this.download_headers = opts.download_headers;
+    this.upload_headers = opts.upload_headers;
     this.bytes_transferred = 0;
     this._timeout = setTimeout(this._onTimeout.bind(this), opts.ttl);
   }

--- a/test/standalone-server.js
+++ b/test/standalone-server.js
@@ -417,6 +417,62 @@ module.exports = {
       server.handleRequest(reqCreate, resCreate);
     },
 
+    'should send 400 if custom download header name is invalid': function(done) {
+      var server = new StandaloneServer({session_ttl: 5});
+      var reqCreate = new MockReq({method: 'POST', url: '/stream'});
+      reqCreate.write('{ "download_headers": { "@{}[].<>": 1 } }');
+      reqCreate.end();
+      var resCreate = new MockRes(() =>{
+        assert.equal(resCreate.statusCode, 400);
+        assert.equal(resCreate._getString(), 'Not a valid HTTP header name: @{}[].<>');
+        done();
+      });
+
+      server.handleRequest(reqCreate, resCreate);
+    },
+
+    'should send 400 if custom download header value is invalid': function(done) {
+      var server = new StandaloneServer({session_ttl: 5});
+      var reqCreate = new MockReq({method: 'POST', url: '/stream'});
+      reqCreate.write('{ "download_headers": { "aa": "\\b" } }');
+      reqCreate.end();
+      var resCreate = new MockRes(() =>{
+        assert.equal(resCreate.statusCode, 400);
+        assert.equal(resCreate._getString(), 'Not a valid HTTP header value: "\b"');
+        done();
+      });
+
+      server.handleRequest(reqCreate, resCreate);
+    },
+
+    'should send 400 if custom upload header name is invalid': function(done) {
+      var server = new StandaloneServer({session_ttl: 5});
+      var reqCreate = new MockReq({method: 'POST', url: '/stream'});
+      reqCreate.write('{ "upload_headers": { "@{}[].<>": 1 } }');
+      reqCreate.end();
+      var resCreate = new MockRes(() =>{
+        assert.equal(resCreate.statusCode, 400);
+        assert.equal(resCreate._getString(), 'Not a valid HTTP header name: @{}[].<>');
+        done();
+      });
+
+      server.handleRequest(reqCreate, resCreate);
+    },
+
+    'should send 400 if custom upload header value is invalid': function(done) {
+      var server = new StandaloneServer({session_ttl: 5});
+      var reqCreate = new MockReq({method: 'POST', url: '/stream'});
+      reqCreate.write('{ "upload_headers": { "aa": "\\b" } }');
+      reqCreate.end();
+      var resCreate = new MockRes(() =>{
+        assert.equal(resCreate.statusCode, 400);
+        assert.equal(resCreate._getString(), 'Not a valid HTTP header value: "\b"');
+        done();
+      });
+
+      server.handleRequest(reqCreate, resCreate);
+    },
+
     'should respond to GET with any provided download headers': function(done) {
       var server = new StandaloneServer({session_ttl: 5});
       var reqCreate = new MockReq({method: 'POST', url: '/stream'});


### PR DESCRIPTION
Implementing Issue #1: Added content type and filename parameters that can be provided as JSON in the POST body when registering the stream.