### PR TITLE
Error Messaging

### DIFF
--- a/lib/servers/standalone.js
+++ b/lib/servers/standalone.js
@@ -114,6 +114,7 @@ class StandaloneServer {
     else if (this._isErr(req.method, req.url)) {
       let stream_id = req.url.match(STREAM_ERROR_URL_REGEX)[1];
       let sess = this._manager.getSession(stream_id);
+      if(!sess) return this._replyError(res, HTTP_STATUS.NotFound);
       if (sess._piped || sess.deleted) return this._replyError(res, HTTP_STATUS.Conflict);
 
       let content = "";
@@ -123,7 +124,6 @@ class StandaloneServer {
       req.once('end', () => {
         try { var body = JSON.parse(content) }
         catch(err) { return this._replyError(res, HTTP_STATUS.BadRequest) }
-        if (!body) return this._replyError(res, HTTP_STATUS.BadRequest);
 
         sess.registerClientError(body);
         res.statusCode = HTTP_STATUS.OK;

--- a/lib/servers/standalone.js
+++ b/lib/servers/standalone.js
@@ -6,6 +6,17 @@ const STREAM_URL_REGEX = /^\/stream\/([a-zA-Z0-9-_]+)\/?$/;
 const STREAM_ERROR_URL_REGEX = /^\/stream\/([a-zA-Z0-9-_]+)\/error\/?$/;
 const SESSION_TTL = 60000;
 
+const HTTP_STATUS = {
+  OK: 200,
+  Created: 201,
+  BadRequest: 400,
+  NotFound: 404,
+  Conflict: 409,
+  TooManyRequests: 429,
+  BadGateway: 502,
+  GatewayTimeout: 504
+};
+
 const STREAM_ERRORS = {
   'SRC_ERROR': JSON.stringify({name: 'StreamSourceError', message: 'Stream source raised an error'}),
   'DST_ERROR': JSON.stringify({name: 'StreamDestinationError', message: 'Stream destination raised an error'}),
@@ -33,13 +44,13 @@ class StandaloneServer {
 
       req.once('end', () => {
         try { var body = content ? JSON.parse(content) : {} }
-        catch(err) { return this._replyBadRequest(res) }
-        if (!body) return this._replyBadRequest(res);
+        catch(err) { return this._replyError(res, HTTP_STATUS.BadRequest) }
+        if (!body) return this._replyError(res, HTTP_STATUS.BadRequest);
 
         var sess = this._manager.createSession(body.download_headers, body.upload_headers);
         this.logger.info('session '+sess.id+' created');
 
-        res.statusCode = 201;
+        res.statusCode = HTTP_STATUS.Created;
         res.setHeader('content-type', 'application/json');
         return res.end('{"stream":"'+sess.id+'"}');
       });
@@ -48,7 +59,7 @@ class StandaloneServer {
     // PUT /session/{id}
     else if(this._isSrc(req.method, req.url)) {
       var sess = this._manager.getSession(this._getStreamId(req.url));
-      if(!sess) return this._replyNotFound(res);
+      if(!sess) return this._replyError(res, HTTP_STATUS.NotFound);
 
       if (!!sess.client_error) {
         return this._onClientError(sess, res);
@@ -61,21 +72,21 @@ class StandaloneServer {
           this.logger.info('setting provided upload header: '+header);
           res.setHeader(header, sess.upload_headers[header]);
         }
-        res.statusCode = 200;
+        res.statusCode = HTTP_STATUS.OK;
       });
       sess.on('client_error', sess => this._onClientError(sess, res));
-      sess.on('timeout', sess => this._replyGatewayTimeout(res));
+      sess.on('timeout', sess => this._replyError(res, HTTP_STATUS.GatewayTimeout));
       sess.on('error', err => this._onSessionError('src', sess, err, req, res));
       sess.on('finished', sess => res.end());
 
       try { sess.registerSource(req) }
-      catch(err) { return this._replyForbidden(res); }
+      catch(err) { return this._replyError(res, HTTP_STATUS.TooManyRequests); }
     }
 
     // GET /session/{id}
     else if(this._isDst(req.method, req.url)) {
       var sess = this._manager.getSession(this._getStreamId(req.url));
-      if(!sess) return this._replyNotFound(res);
+      if(!sess) return this._replyError(res, HTTP_STATUS.NotFound);
 
       if (!!sess.client_error) {
         return this._onClientError(sess, res);
@@ -87,23 +98,23 @@ class StandaloneServer {
           this.logger.info('setting provided download header: '+header);
           res.setHeader(header, sess.download_headers[header]);
         }
-        res.statusCode = 200;
+        res.statusCode = HTTP_STATUS.OK;
         res.setHeader('connection', 'close');
       });
       sess.on('client_error', sess => this._onClientError(sess, res));
-      sess.on('timeout', sess => this._replyGatewayTimeout(res));
+      sess.on('timeout', sess => this._replyError(res, HTTP_STATUS.GatewayTimeout));
       sess.on('error', err => this._onSessionError('dst', sess, err, req, res));
       sess.on('finished', sess => res.end());
 
       try { sess.registerDestination(res) }
-      catch(err) { return this._replyForbidden(res); }
+      catch(err) { return this._replyError(res, HTTP_STATUS.TooManyRequests); }
     }
 
     // POST /session/{id}/error
     else if (this._isErr(req.method, req.url)) {
       let stream_id = req.url.match(STREAM_ERROR_URL_REGEX)[1];
       let sess = this._manager.getSession(stream_id);
-      if (sess._piped || sess.deleted) return this._replyConflict(res);
+      if (sess._piped || sess.deleted) return this._replyError(res, HTTP_STATUS.Conflict);
 
       let content = "";
       req.setEncoding("utf8");
@@ -111,17 +122,17 @@ class StandaloneServer {
 
       req.once('end', () => {
         try { var body = JSON.parse(content) }
-        catch(err) { return this._replyBadRequest(res) }
-        if (!body || !body.error) return this._replyBadRequest(res);
+        catch(err) { return this._replyError(res, HTTP_STATUS.BadRequest) }
+        if (!body) return this._replyError(res, HTTP_STATUS.BadRequest);
 
-        sess.registerClientError(error);
-        res.statusCode = 200;
+        sess.registerClientError(body);
+        res.statusCode = HTTP_STATUS.OK;
         res.end();
       });
     }
 
     // 404
-    else return this._replyNotFound(res);
+    else return this._replyError(res, HTTP_STATUS.NotFound);
   }
 
   _isCreate(method, url) { return method === 'POST' && url.search(STREAM_GENERATOR_URL_REGEX) !== -1; }
@@ -135,41 +146,31 @@ class StandaloneServer {
     return res.end(msg);
   }
 
-  _replyConflict(res, msg) {
-    return this._replyError(res, 409, msg);
-  }
-  _replyNotFound(res, msg) {
-    return this._replyError(res, 404, msg);
-  }
-  _replyForbidden(res, msg) {
-    return this._replyError(res, 403, msg);
-  }
-  _replyBadRequest(res, msg) {
-    return this._replyError(res, 400, msg);
-  }
-  _replyGatewayTimeout(res, msg) {
-    return this._replyError(res, 504, msg);
-  }
-
   _onClientError(sess, res) {
-    let err = sess.client_error;
-    let response_body = JSON.stringify({ name: err.name, message: err.message });
-    return this._replyError(res, err.http_status, response_body);
+    var http_status = 400;
+    var response_body = { name: "Error", message: "The other side encountered an unspecified error" };
+    var err = sess.client_error;
+    if (!!err) {
+      if (err.http_status) http_status = err.http_status;
+      if (err.name) response_body.name = err.name;
+      if (err.message) response_body.message = err.message;
+    }
+
+    return this._replyError(res, http_status, JSON.stringify(response_body));
   }
 
   _onSessionError(side, sess, err, req, res) {
-    var outErr = STREAM_ERRORS[sess.state];
-    if(!outErr) outErr = STREAM_ERRORS['_DEFAULT'];
-    if(side === 'src') {
-      if(sess.state === 'SRC_DISCONNECTED') return;
-      res.write(outErr);
-      res.end();
-    }
-    else {
-      if(sess.state === 'DST_DISCONNECTED') return;
-      res.write('\n\n'+outErr);
-      res.end();
-    }
+    var outErr = STREAM_ERRORS[sess.state] || STREAM_ERRORS['_DEFAULT'];
+    // dst may already have content written so add line breaks for readability
+    if (side === 'dst') outErr = '\n\n'+outErr;
+
+    // don't bother trying to write error messages if already disconnected
+    var SIDE = side.toUpperCase();
+    if(sess.state === `${SIDE}_DISCONNECTED`) return;
+
+    // don't try to set the status if the headers can't be changed
+    if(res.headersSent) { res.end(outErr); }
+    else { this._replyError(res, HTTP_STATUS.BadGateway, outErr); }
   }
 }
 

--- a/lib/servers/standalone.js
+++ b/lib/servers/standalone.js
@@ -49,7 +49,7 @@ class StandaloneServer {
 
       req.once('end', () => {
         try { var body = this._parseCreateContent(content) }
-        catch(err) { return this._replyError(res, HTTP_STATUS.BadRequest) }
+        catch(err) { return this._replyError(res, HTTP_STATUS.BadRequest, err.message) }
 
         var sess = this._manager.createSession(body.download_headers, body.upload_headers);
         this.logger.info('session '+sess.id+' created');

--- a/lib/servers/standalone.js
+++ b/lib/servers/standalone.js
@@ -61,7 +61,7 @@ class StandaloneServer {
         catch(err) { return this._replyError(res, HTTP_STATUS.BadRequest, SERVER_ERROR.BAD_BODY(err.message)) }
 
         var sess = this._manager.createSession(body.download_headers, body.upload_headers);
-        this.logger.info('session '+sess.id+' created');
+        sess.logger.info('session '+sess.id+' created');
 
         res.statusCode = HTTP_STATUS.Created;
         res.setHeader('content-type', 'application/json');
@@ -82,7 +82,7 @@ class StandaloneServer {
         res.setHeader('connection', 'close');
         // map upload_headers object key/values to actual response header/values
         for (var header in sess.upload_headers) {
-          this.logger.info('setting provided upload header: '+header);
+          sess.logger.info('setting provided upload header: '+header);
           res.setHeader(header, sess.upload_headers[header]);
         }
         res.statusCode = HTTP_STATUS.OK;

--- a/lib/servers/standalone.js
+++ b/lib/servers/standalone.js
@@ -108,7 +108,7 @@ class StandaloneServer {
       sess.on('streaming', sess => {
         // map download_headers object key/values to actual response header/values
         for (var header in sess.download_headers) {
-          this.logger.info('setting provided download header: '+header);
+          sess.logger.info('setting provided download header: '+header);
           res.setHeader(header, sess.download_headers[header]);
         }
         res.statusCode = HTTP_STATUS.OK;

--- a/lib/servers/standalone.js
+++ b/lib/servers/standalone.js
@@ -22,12 +22,21 @@ const HTTP_STATUS = {
   GatewayTimeout: 504
 };
 
+const SERVER_ERROR = {
+  'BAD_BODY': (message) => ({name: 'InvalidBodyError', message}),
+  'CONN_EXISTS': (side) => ({name: 'AlreadyConnectedError', message: 'A client has already connected to the '+side+' side of this stream'}),
+  'SESS_NOT_FOUND': () => ({name: 'SessionNotFoundError', message: 'The specified session id does not exist'}),
+  'BAD_ROUTE': () => ({name: 'BadRouteError', message: 'No endpoint exists for the specified method and/or route'}),
+  'TIMEOUT': () => ({name: 'SessionTimeoutError', message: 'The specified session expired before both sides connected'}),
+  'STARTED': () => ({name: 'StreamStartedError', message: 'The specified session has already started streaming'})
+};
+
 const STREAM_ERRORS = {
-  'SRC_ERROR': JSON.stringify({name: 'StreamSourceError', message: 'Stream source raised an error'}),
-  'DST_ERROR': JSON.stringify({name: 'StreamDestinationError', message: 'Stream destination raised an error'}),
-  'SRC_DISCONNECTED': JSON.stringify({name: 'StreamSourceError', message: 'Stream source closed unexpectedly'}),
-  'DST_DISCONNECTED': JSON.stringify({name: 'StreamDestinationError', message: 'Stream destination closed unexpectedly'}),
-  '_DEFAULT': JSON.stringify({name: 'StreamError', message: 'Stream raised an error'})
+  'SRC_ERROR': {name: 'StreamSourceError', message: 'Stream source raised an error'},
+  'DST_ERROR': {name: 'StreamDestinationError', message: 'Stream destination raised an error'},
+  'SRC_DISCONNECTED': {name: 'StreamSourceError', message: 'Stream source closed unexpectedly'},
+  'DST_DISCONNECTED': {name: 'StreamDestinationError', message: 'Stream destination closed unexpectedly'},
+  '_DEFAULT': {name: 'StreamError', message: 'Stream raised an error'}
 };
 
 class StandaloneServer {
@@ -49,7 +58,7 @@ class StandaloneServer {
 
       req.once('end', () => {
         try { var body = this._parseCreateContent(content) }
-        catch(err) { return this._replyError(res, HTTP_STATUS.BadRequest, err.message) }
+        catch(err) { return this._replyError(res, HTTP_STATUS.BadRequest, SERVER_ERROR.BAD_BODY(err.message)) }
 
         var sess = this._manager.createSession(body.download_headers, body.upload_headers);
         this.logger.info('session '+sess.id+' created');
@@ -63,7 +72,7 @@ class StandaloneServer {
     // PUT /session/{id}
     else if(this._isSrc(req.method, req.url)) {
       var sess = this._manager.getSession(this._getStreamId(req.url));
-      if(!sess) return this._replyError(res, HTTP_STATUS.NotFound);
+      if(!sess) return this._replyError(res, HTTP_STATUS.NotFound, SERVER_ERROR.SESS_NOT_FOUND());
 
       if (!!sess.client_error) {
         return this._onClientError(sess, res);
@@ -79,18 +88,18 @@ class StandaloneServer {
         res.statusCode = HTTP_STATUS.OK;
       });
       sess.on('client_error', sess => this._onClientError(sess, res));
-      sess.on('timeout', sess => this._replyError(res, HTTP_STATUS.GatewayTimeout));
+      sess.on('timeout', sess => this._replyError(res, HTTP_STATUS.GatewayTimeout, SERVER_ERROR.TIMEOUT()));
       sess.on('error', err => this._onSessionError('src', sess, err, req, res));
       sess.on('finished', sess => res.end());
 
       try { sess.registerSource(req) }
-      catch(err) { return this._replyError(res, HTTP_STATUS.TooManyRequests); }
+      catch(err) { return this._replyError(res, HTTP_STATUS.TooManyRequests, SERVER_ERROR.CONN_EXISTS("source")); }
     }
 
     // GET /session/{id}
     else if(this._isDst(req.method, req.url)) {
       var sess = this._manager.getSession(this._getStreamId(req.url));
-      if(!sess) return this._replyError(res, HTTP_STATUS.NotFound);
+      if(!sess) return this._replyError(res, HTTP_STATUS.NotFound, SERVER_ERROR.SESS_NOT_FOUND());
 
       if (!!sess.client_error) {
         return this._onClientError(sess, res);
@@ -106,20 +115,20 @@ class StandaloneServer {
         res.setHeader('connection', 'close');
       });
       sess.on('client_error', sess => this._onClientError(sess, res));
-      sess.on('timeout', sess => this._replyError(res, HTTP_STATUS.GatewayTimeout));
+      sess.on('timeout', sess => this._replyError(res, HTTP_STATUS.GatewayTimeout, SERVER_ERROR.TIMEOUT()));
       sess.on('error', err => this._onSessionError('dst', sess, err, req, res));
       sess.on('finished', sess => res.end());
 
       try { sess.registerDestination(res) }
-      catch(err) { return this._replyError(res, HTTP_STATUS.TooManyRequests); }
+      catch(err) { return this._replyError(res, HTTP_STATUS.TooManyRequests, SERVER_ERROR.CONN_EXISTS("destination")); }
     }
 
     // POST /session/{id}/error
     else if (this._isErr(req.method, req.url)) {
       let stream_id = req.url.match(STREAM_ERROR_URL_REGEX)[1];
       let sess = this._manager.getSession(stream_id);
-      if(!sess) return this._replyError(res, HTTP_STATUS.NotFound);
-      if (sess._piped || sess.deleted) return this._replyError(res, HTTP_STATUS.Conflict);
+      if(!sess) return this._replyError(res, HTTP_STATUS.NotFound, SERVER_ERROR.SESS_NOT_FOUND());
+      if (sess._piped || sess.deleted) return this._replyError(res, HTTP_STATUS.Conflict, SERVER_ERROR.STARTED());
 
       let content = "";
       req.setEncoding("utf8");
@@ -127,7 +136,7 @@ class StandaloneServer {
 
       req.once('end', () => {
         try { var body = JSON.parse(content) }
-        catch(err) { return this._replyError(res, HTTP_STATUS.BadRequest) }
+        catch(err) { return this._replyError(res, HTTP_STATUS.BadRequest, SERVER_ERROR.BAD_BODY(err.message)) }
 
         sess.registerClientError(body);
         res.statusCode = HTTP_STATUS.OK;
@@ -136,7 +145,7 @@ class StandaloneServer {
     }
 
     // 404
-    else return this._replyError(res, HTTP_STATUS.NotFound);
+    else return this._replyError(res, HTTP_STATUS.NotFound, SERVER_ERROR.BAD_ROUTE());
   }
 
   _isCreate(method, url) { return method === 'POST' && url.search(STREAM_GENERATOR_URL_REGEX) !== -1; }
@@ -144,11 +153,6 @@ class StandaloneServer {
   _isDst(method, url) { return method === 'GET' && url.search(STREAM_URL_REGEX) !== -1; }
   _isErr(method, url) { return method === 'POST' && url.search(STREAM_ERROR_URL_REGEX) !== -1;  }
   _getStreamId(url) { return url.match(STREAM_URL_REGEX)[1]; }
-
-  _replyError(res, http_status, msg) {
-    res.statusCode = http_status;
-    return res.end(msg);
-  }
 
   _parseCreateContent(content) {
     var body = { download_headers:[], upload_headers:[] };
@@ -171,31 +175,43 @@ class StandaloneServer {
     return body;
   }
 
+  _replyError(res, http_status, error) {
+    var response_body = { name: "Error", message: "Encountered an error" };
+    if (!!error) {
+      if (error.name) response_body.name = error.name;
+      if (error.message) response_body.message = error.message;
+    }
+
+    res.statusCode = http_status;
+    res.setHeader('content-type', 'application/json');
+    return res.end(JSON.stringify(response_body));
+  }
 
   _onClientError(sess, res) {
     var http_status = 400;
     var response_body = { name: "Error", message: "The other side encountered an unspecified error" };
-    var err = sess.client_error;
-    if (!!err) {
-      if (err.http_status) http_status = err.http_status;
-      if (err.name) response_body.name = err.name;
-      if (err.message) response_body.message = err.message;
+
+    var error = sess.client_error;
+    if (!!error) {
+      if (error.http_status) http_status = error.http_status;
+      if (error.name) response_body.name = error.name;
+      if (error.message) response_body.message = error.message;
     }
 
-    return this._replyError(res, http_status, JSON.stringify(response_body));
+    return this._replyError(res, http_status, response_body);
   }
 
   _onSessionError(side, sess, err, req, res) {
     var outErr = STREAM_ERRORS[sess.state] || STREAM_ERRORS['_DEFAULT'];
-    // dst may already have content written so add line breaks for readability
-    if (side === 'dst') outErr = '\n\n'+outErr;
 
     // don't bother trying to write error messages if already disconnected
     var SIDE = side.toUpperCase();
     if(sess.state === `${SIDE}_DISCONNECTED`) return;
 
     // don't try to set the status if the headers can't be changed
-    if(res.headersSent) { res.end(outErr); }
+    // if they are already sent, we've probably already sent some content too,
+    // so we add line breaks for readability
+    if(res.headersSent) { res.end('\n\n'+JSON.stringify(outErr)); }
     else { this._replyError(res, HTTP_STATUS.BadGateway, outErr); }
   }
 }

--- a/lib/servers/standalone.js
+++ b/lib/servers/standalone.js
@@ -3,6 +3,7 @@ const NOOP_LOGGER = require('../noop-logger');
 
 const STREAM_GENERATOR_URL_REGEX = /^\/stream\/?$/;
 const STREAM_URL_REGEX = /^\/stream\/([a-zA-Z0-9-_]+)\/?$/;
+const STREAM_ERROR_URL_REGEX = /^\/stream\/([a-zA-Z0-9-_]+)\/error\/?$/;
 const SESSION_TTL = 60000;
 
 const STREAM_ERRORS = {
@@ -33,6 +34,7 @@ class StandaloneServer {
       req.once('end', () => {
         try { var body = content ? JSON.parse(content) : {} }
         catch(err) { return this._replyBadRequest(res) }
+        if (!body) return this._replyBadRequest(res);
 
         var sess = this._manager.createSession(body.download_headers, body.upload_headers);
         this.logger.info('session '+sess.id+' created');
@@ -48,21 +50,26 @@ class StandaloneServer {
       var sess = this._manager.getSession(this._getStreamId(req.url));
       if(!sess) return this._replyNotFound(res);
 
-      try { sess.registerSource(req) }
-      catch(err) { return this._replyForbidden(res); }
-
-      res.setHeader('connection', 'close');
-
-      // map upload_headers object key/values to actual response header/values
-      for (var header in sess.upload_headers) {
-        this.logger.info('setting provided upload header: '+header);
-        res.setHeader(header, sess.upload_headers[header]);
+      if (!!sess.client_error) {
+        return this._onClientError(sess, res);
       }
 
+      sess.on('streaming', sess => {
+        res.setHeader('connection', 'close');
+        // map upload_headers object key/values to actual response header/values
+        for (var header in sess.upload_headers) {
+          this.logger.info('setting provided upload header: '+header);
+          res.setHeader(header, sess.upload_headers[header]);
+        }
+        res.statusCode = 200;
+      });
+      sess.on('client_error', sess => this._onClientError(sess, res));
       sess.on('timeout', sess => this._replyGatewayTimeout(res));
-      sess.on('streaming', sess => res.statusCode = 200);
       sess.on('error', err => this._onSessionError('src', sess, err, req, res));
       sess.on('finished', sess => res.end());
+
+      try { sess.registerSource(req) }
+      catch(err) { return this._replyForbidden(res); }
     }
 
     // GET /session/{id}
@@ -70,21 +77,47 @@ class StandaloneServer {
       var sess = this._manager.getSession(this._getStreamId(req.url));
       if(!sess) return this._replyNotFound(res);
 
-      try { sess.registerDestination(res) }
-      catch(err) { return this._replyForbidden(res); }
-
-      res.setHeader('connection', 'close');
-
-      // map download_headers object key/values to actual response header/values
-      for (var header in sess.download_headers) {
-        this.logger.info('setting provided download header: '+header);
-        res.setHeader(header, sess.download_headers[header]);
+      if (!!sess.client_error) {
+        return this._onClientError(sess, res);
       }
 
-      sess.on('streaming', sess => res.statusCode = 200);
+      sess.on('streaming', sess => {
+        // map download_headers object key/values to actual response header/values
+        for (var header in sess.download_headers) {
+          this.logger.info('setting provided download header: '+header);
+          res.setHeader(header, sess.download_headers[header]);
+        }
+        res.statusCode = 200;
+        res.setHeader('connection', 'close');
+      });
+      sess.on('client_error', sess => this._onClientError(sess, res));
       sess.on('timeout', sess => this._replyGatewayTimeout(res));
       sess.on('error', err => this._onSessionError('dst', sess, err, req, res));
       sess.on('finished', sess => res.end());
+
+      try { sess.registerDestination(res) }
+      catch(err) { return this._replyForbidden(res); }
+    }
+
+    // POST /session/{id}/error
+    else if (this._isErr(req.method, req.url)) {
+      let stream_id = req.url.match(STREAM_ERROR_URL_REGEX)[1];
+      let sess = this._manager.getSession(stream_id);
+      if (sess._piped || sess.deleted) return this._replyConflict(res);
+
+      let content = "";
+      req.setEncoding("utf8");
+      req.on('data', data => { content += data });
+
+      req.once('end', () => {
+        try { var body = JSON.parse(content) }
+        catch(err) { return this._replyBadRequest(res) }
+        if (!body || !body.error) return this._replyBadRequest(res);
+
+        sess.registerClientError(error);
+        res.statusCode = 200;
+        res.end();
+      });
     }
 
     // 404
@@ -94,23 +127,34 @@ class StandaloneServer {
   _isCreate(method, url) { return method === 'POST' && url.search(STREAM_GENERATOR_URL_REGEX) !== -1; }
   _isSrc(method, url) { return method === 'PUT' && url.search(STREAM_URL_REGEX) !== -1; }
   _isDst(method, url) { return method === 'GET' && url.search(STREAM_URL_REGEX) !== -1; }
+  _isErr(method, url) { return method === 'POST' && url.search(STREAM_ERROR_URL_REGEX) !== -1;  }
   _getStreamId(url) { return url.match(STREAM_URL_REGEX)[1]; }
 
-  _replyNotFound(res, msg) {
-    res.statusCode = 404;
+  _replyError(res, http_status, msg) {
+    res.statusCode = http_status;
     return res.end(msg);
+  }
+
+  _replyConflict(res, msg) {
+    return this._replyError(res, 409, msg);
+  }
+  _replyNotFound(res, msg) {
+    return this._replyError(res, 404, msg);
   }
   _replyForbidden(res, msg) {
-    res.statusCode = 403;
-    return res.end(msg);
+    return this._replyError(res, 403, msg);
   }
   _replyBadRequest(res, msg) {
-    res.statusCode = 400;
-    return res.end(msg);
+    return this._replyError(res, 400, msg);
   }
   _replyGatewayTimeout(res, msg) {
-    res.statusCode = 504;
-    return res.end(msg);
+    return this._replyError(res, 504, msg);
+  }
+
+  _onClientError(sess, res) {
+    let err = sess.client_error;
+    let response_body = JSON.stringify({ name: err.name, message: err.message });
+    return this._replyError(res, err.http_status, response_body);
   }
 
   _onSessionError(side, sess, err, req, res) {

--- a/lib/session-manager.js
+++ b/lib/session-manager.js
@@ -60,6 +60,13 @@ class Session extends EventEmitter {
     return this;
   }
 
+  registerClientError(err) {
+    this.client_error = err;
+    this.state = 'CLIENT_ERROR';
+    this.emit('client_error', this);
+    this.delete();
+  }
+
   _attemptStreamStart() {
     if(!this._src && !this._dst) return;
     else if(this._src && !this._dst) this.state = 'SRC_CONNECTED';

--- a/test/standalone-server.js
+++ b/test/standalone-server.js
@@ -738,7 +738,7 @@ module.exports = {
     },
 
     'should send 400 if custom download header name is invalid': function(done) {
-      var server = new StandaloneServer({session_ttl: 5});
+      var server = new StandaloneServer({});
       var reqCreate = new MockReq({method: 'POST', url: '/stream'});
       reqCreate.write('{ "download_headers": { "@{}[].<>": 1 } }');
       reqCreate.end();


### PR DESCRIPTION
We had a request to make it easier to distinguish when something goes wrong. In particular, if one side of the stream encounters a problem like a nonexistent path or bad permissions, there's currently no way for it to let the other side know about that.

This PR includes:
- a new endpoint that allows for such signalling
- improved error messaging for bad requests and timeouts
- updated README documentation