### PR TITLE
Made socket timeout allow for extremely long pauses during transfers

### DIFF
--- a/lib/servers/standalone.js
+++ b/lib/servers/standalone.js
@@ -77,6 +77,7 @@ class StandaloneServer {
 
     // PUT /stream/{id}
     else if(this._isSrc(req.method, pathname)) {
+      req.setTimeout(6 * 60 * 60 * 1000);
       var sess = this._manager.getSession(this._getStreamId(pathname));
       if(!sess) return this._replyError(res, HTTP_STATUS.NotFound, SERVER_ERROR.SESS_NOT_FOUND());
 
@@ -104,6 +105,7 @@ class StandaloneServer {
 
     // GET /stream/{id}
     else if(this._isDst(req.method, pathname)) {
+      req.setTimeout(6 * 60 * 60 * 1000);
       var sess = this._manager.getSession(this._getStreamId(pathname));
       if(!sess) return this._replyError(res, HTTP_STATUS.NotFound, SERVER_ERROR.SESS_NOT_FOUND());
 

--- a/test/standalone-server.js
+++ b/test/standalone-server.js
@@ -7,6 +7,8 @@ const MockRes = require('mock-res');
 
 const StandaloneServer = require('../lib/servers/standalone');
 
+MockReq.prototype.setTimeout = ()=>{};
+
 function assertErrorResponse(res, http_status, name, message) {
   assert.equal(res.statusCode, http_status);
   let body = JSON.parse(res._getString());


### PR DESCRIPTION
Under high load, we've sometimes some transfers get delayed for several minutes, causing socket timeouts with rendezvous. This increases that timeout value to a crazy high amount of time for both sides of the transfer. If they hit this timeout, they deserve to die lol.